### PR TITLE
CortexM0: IPR and SHPR are only word addressable

### DIFF
--- a/include/libopencm3/cm3/nvic.h
+++ b/include/libopencm3/cm3/nvic.h
@@ -86,9 +86,14 @@
 
 /* IPR: Interrupt Priority Registers */
 /* Note: 240 8bit Registers */
-/* Note: 32 8bit Registers on CM0 */
+/* Note: 8 32bit Registers on CM0, requires word access */
+#if defined(__ARM_ARCH_6M__)
+#define NVIC_IPR32(ipr_id)		MMIO32(NVIC_BASE + 0x300 + \
+						((ipr_id) * 4))
+#else
 #define NVIC_IPR(ipr_id)		MMIO8(NVIC_BASE + 0x300 + \
 						(ipr_id))
+#endif
 
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 /* STIR: Software Trigger Interrupt Register */

--- a/include/libopencm3/cm3/scs.h
+++ b/include/libopencm3/cm3/scs.h
@@ -52,8 +52,14 @@
 
 /** System Handler Priority 8 bits Registers, SHPR1/2/3.
  * Note: 12 8bit Registers
+ * Note: 3 32bit Registers on CM0, requires word access
  */
+#if defined(__ARM_ARCH_6M__)
+#define SCS_SHPR32(ipr_id)		MMIO32(SCS_BASE + 0xD18 + ((ipr_id) * 4))
+#else
 #define SCS_SHPR(ipr_id)		MMIO8(SCS_BASE + 0xD18 + (ipr_id))
+#endif
+
 
 /**
  * Debug Halting Control and Status Register (DHCSR).


### PR DESCRIPTION
For ARMv6M, the IPR and SHPR registers are accessible only when
adddressed with a 32bit word read or write.

Currently in libopencm3 all NVIC interrupt priority register accesses
are made using an 8bit read or write, which results in the hardware
ignoring the write or always returning 0 on read.

Address this by introducing NVIC_IPR32() and SCS_SHPR32() macro and
conditional implementation of nvic_set_priority when building for
cortex-m0.

See ARMv6M developer documentation:
IPR: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/Cihgjeed.html
SHPR: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/CIAGECDD.html